### PR TITLE
add additional env variables to credit distributor

### DIFF
--- a/credit-distributor/docker-compose.yml
+++ b/credit-distributor/docker-compose.yml
@@ -8,6 +8,9 @@ services:
       SCHAIN_NAME: ${SCHAIN_NAME}
       FROM_BLOCK: ${FROM_BLOCK}
       ETH_PRIVATE_KEY: ${ETH_PRIVATE_KEY}
+      PAYMENT_VALUE_ETH: ${PAYMENT_VALUE_ETH}
+      AGENT_EXCEPTION_SLEEP: ${AGENT_EXCEPTION_SLEEP}
+      AGENT_LOOP_SLEEP: ${AGENT_LOOP_SLEEP}
     image: credit-distributor:latest
     container_name: credit_distributor
     build:

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,3 +1,4 @@
 {
-    "filter_paths": "node_modules|hardhat-dependency-compiler"
+    "filter_paths": "node_modules|hardhat-dependency-compiler",
+    "detectors_to_exclude": "unindexed-event-address"
 }


### PR DESCRIPTION
This pull request introduces a few new environment variables to the `credit-distributor` service configuration in `docker-compose.yml` to allow for more flexible runtime configuration.

- Environment variable additions:
  * Added `PAYMENT_VALUE_ETH`, `AGENT_EXCEPTION_SLEEP`, and `AGENT_LOOP_SLEEP` as environment variables for the `credit-distributor` service, enabling configurable payment values and agent sleep durations.