### PR TITLE
fix payment wei value in credit distributor

### DIFF
--- a/credit-distributor/src/configs.py
+++ b/credit-distributor/src/configs.py
@@ -49,7 +49,6 @@ class Agent(BaseModel):
 
 class Payment(BaseModel):
     value_eth: int = 1
-    value_wei: int = value_eth * 10**18
 
 
 class General(BaseModel):

--- a/credit-distributor/src/main.py
+++ b/credit-distributor/src/main.py
@@ -76,6 +76,10 @@ def distribute_credits(
     return state
 
 
+def get_payment_wei_value(config: Config) -> int:
+    return config.payment.value_eth * 10**18
+
+
 def fulfill_payment(
     event: PaymentReceivedEvent, schain_cs: SchainCreditStation, config: Config
 ) -> None:
@@ -84,7 +88,7 @@ def fulfill_payment(
     if not is_fulfilled:
         logger.info(f'Fulfilling payment: {event["payment_id"]}')
         schain_cs.ledger.fulfill(
-            event['payment_id'], event['to_address'], value=config.payment.value_wei
+            event['payment_id'], event['to_address'], value=get_payment_wei_value(config)
         )
         logger.info(f'Payment {event["payment_id"]} fulfilled successfully.')
     else:


### PR DESCRIPTION
This pull request refactors how the payment value in wei is calculated and used throughout the codebase. Instead of storing the wei value as a static field in the configuration, it is now computed dynamically when needed. This change reduces redundancy and ensures that the wei value always reflects the current ETH value in the configuration.

**Configuration and payment logic refactor:**

* Removed the `value_wei` field from the `Payment` configuration model in `configs.py` to avoid storing a redundant value.
* Introduced a new function `get_payment_wei_value` in `main.py` to dynamically calculate the payment value in wei based on the current `value_eth` in the config.
* Updated the `fulfill_payment` function to use the new `get_payment_wei_value` function instead of accessing a static `value_wei` field, ensuring consistency and up-to-date calculations.