### PR TITLE
set chunk size to 2000 for events

### DIFF
--- a/credit-distributor/config.toml.example
+++ b/credit-distributor/config.toml.example
@@ -26,3 +26,4 @@ from_block = 5678
 [agent] # optional
 loop_sleep = 120 # optional
 exception_sleep = 10 # optional
+events_chunk_size = 2000 # optional - block range size for event log queries

--- a/credit-distributor/src/configs.py
+++ b/credit-distributor/src/configs.py
@@ -50,6 +50,7 @@ class Destination(BaseModel):
 class Agent(BaseModel):
     loop_sleep: int = 120
     exception_sleep: int = 10
+    events_chunk_size: int = 2000
 
 
 class General(BaseModel):

--- a/credit-distributor/src/main.py
+++ b/credit-distributor/src/main.py
@@ -88,7 +88,9 @@ def distribute_credits_for_source(
     from_block = state.from_blocks[source.name]
     logger.info(f'[{source.name}] Fetching events from block {from_block}')
     all_events = mainnet_cs.credit_station.get_payment_received_events(
-        from_block=from_block, schain_name=config.general.schain_name
+        from_block=from_block,
+        schain_name=config.general.schain_name,
+        chunk_size=config.agent.events_chunk_size,
     )
     for event in all_events:
         fulfill_payment(source, event, schain_cs)


### PR DESCRIPTION
This pull request introduces a new configuration option to control the size of block ranges used when querying event logs, and updates the codebase to use this new setting. This change allows for more flexible and efficient event fetching by making the chunk size configurable.

Configuration improvements:

* Added a new `events_chunk_size` option to the `[agent]` section in `config.toml.example` to specify the block range size for event log queries.
* Updated the `Agent` model in `configs.py` to include the new `events_chunk_size` configuration with a default value of 2000.

Event fetching logic update:

* Modified the `distribute_credits_for_source` function in `main.py` to pass the configurable `chunk_size` parameter when fetching payment received events, improving control over event log query performance.