### PR TITLE
Fix payment wei value - credit distributor

### DIFF
--- a/credit-distributor/config.toml.example
+++ b/credit-distributor/config.toml.example
@@ -6,6 +6,7 @@ state_file = 'state.json' # optional
 [destination]
 endpoint = 'https://example.com' # required - destination schain RPC
 contract = '0x0' # required - Ledger contract address on destination schain
+credit_decimals = 18 # optional - decimals to scale credit count to native wei (default 18)
 
 # One [[sources]] entry per CreditStation deployment to monitor.
 # Each deployment must have been initialized with a unique on-chain `sourceId`

--- a/credit-distributor/src/configs.py
+++ b/credit-distributor/src/configs.py
@@ -45,6 +45,7 @@ class Source(BaseModel):
 class Destination(BaseModel):
     endpoint: str
     contract: str
+    credit_decimals: int = 18
 
 
 class Agent(BaseModel):

--- a/credit-distributor/src/main.py
+++ b/credit-distributor/src/main.py
@@ -93,7 +93,7 @@ def distribute_credits_for_source(
         chunk_size=config.agent.events_chunk_size,
     )
     for event in all_events:
-        fulfill_payment(source, event, schain_cs)
+        fulfill_payment(source, event, schain_cs, config.destination.credit_decimals)
 
     if all_events:
         state.from_blocks[source.name] = all_events[-1]['block_number'] + 1
@@ -106,13 +106,15 @@ def fulfill_payment(
     source: Source,
     event: PaymentReceivedEvent,
     schain_cs: SchainCreditStation,
+    credit_decimals: int,
 ) -> None:
     payment_id = event['payment_id']
     logger.info(f'[{source.name}] Checking payment: {payment_id}')
     is_fulfilled = schain_cs.ledger.is_fulfilled(payment_id)
     if not is_fulfilled:
-        logger.info(f'[{source.name}] Fulfilling payment: {payment_id}')
-        schain_cs.ledger.fulfill(payment_id, event['to_address'], value=event['value'])
+        amount = event['value'] * (10 ** credit_decimals)
+        logger.info(f'[{source.name}] Fulfilling payment: {payment_id} with amount {amount} wei')
+        schain_cs.ledger.fulfill(payment_id, event['to_address'], value=amount)
         logger.info(f'[{source.name}] Payment {payment_id} fulfilled successfully.')
     else:
         logger.debug(f'[{source.name}] Payment {payment_id} is already fulfilled.')


### PR DESCRIPTION
This pull request updates the credit distribution logic to allow configurable scaling of credit amounts using a new `credit_decimals` parameter. This ensures that credit values are correctly converted to the native unit (wei) when fulfilling payments, improving precision and flexibility.

Configuration and schema changes:

* Added a new optional `credit_decimals` field (default 18) to the `destination` section in `config.toml.example` to allow scaling credit counts to native wei.
* Updated the `Destination` model in `configs.py` to include the new `credit_decimals` parameter with a default value of 18.

Payment fulfillment logic:

* Modified the `distribute_credits_for_source` function to pass the `credit_decimals` value when calling `fulfill_payment`.
* Updated the `fulfill_payment` function to multiply the event value by `10 ** credit_decimals` before fulfilling the payment, ensuring the correct amount is used in wei. Improved logging to reflect the scaled amount.